### PR TITLE
Linting and webpack 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const webpackSources = require('webpack-sources');
 const pluginName = 'PostCSSAssetsPlugin';
 
 module.exports = class PostCSSAssetsPlugin {
-  constructor({test = /\.css$/, plugins = [], log = true} = {}) {
+  constructor({ test = /\.css$/, plugins = [], log = true } = {}) {
     this.test = test;
     this.plugins = plugins;
 
@@ -14,8 +14,8 @@ module.exports = class PostCSSAssetsPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.emit.tapPromise(pluginName, compilation => {
-      const assets = compilation.assets;
+    compiler.hooks.emit.tapPromise(pluginName, (compilation) => {
+      const { assets } = compilation;
 
       this.log('PostCSSAssetsPlugin: Starting...');
 
@@ -46,8 +46,8 @@ module.exports = class PostCSSAssetsPlugin {
           map: (inlineMap || externalMap) ? {
             inline: inlineMap,
             sourcesContent: true,
-            prev: externalMap
-          } : false
+            prev: externalMap,
+          } : false,
         };
 
         this.log(`PostCSSAssetsPlugin: Processing ${name}...`);
@@ -55,9 +55,9 @@ module.exports = class PostCSSAssetsPlugin {
         result.push(
           postcss(this.plugins)
             .process(originalCss, processOptions)
-            .then(result => {
-              const processedCss = result.css;
-              const warnings = result.warnings();
+            .then((postcssResult) => {
+              const processedCss = postcssResult.css;
+              const warnings = postcssResult.warnings();
 
               if (warnings && warnings.length) {
                 this.log('PostCSSAssetsPlugin:', warnings.join('\n'));
@@ -66,27 +66,27 @@ module.exports = class PostCSSAssetsPlugin {
               assets[name] = new webpackSources.RawSource(processedCss);
 
               if (mapAsset) {
-                assets[mapName] = new webpackSources.RawSource(JSON.stringify(result.map));
+                assets[mapName] = new webpackSources.RawSource(JSON.stringify(postcssResult.map));
               }
 
               this.log(
                 'PostCSSAssetsPlugin:',
                 `Processed ${name}. Size before: ${humanSize(originalCss.length, 3)},`,
-                `size after: ${humanSize(processedCss.length, 2)}`
+                `size after: ${humanSize(processedCss.length, 2)}`,
               );
             })
-            .catch(error => {
+            .catch((error) => {
               this.log('PostCSSAssetsPlugin:', `Error processing file: ${name}`, error);
 
               throw error;
-            })
+            }),
         );
 
         return result;
       }, []))
-      .then(() => {
-        this.log('PostCSSAssetsPlugin: Done.');
-      });
+        .then(() => {
+          this.log('PostCSSAssetsPlugin: Done.');
+        });
     });
   }
 };

--- a/index.js
+++ b/index.js
@@ -89,6 +89,15 @@ module.exports = class PostCSSAssetsPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.emit.tapPromise(pluginName, (compilation) => this.run(compilation));
+    const stage = compiler.createCompilation().constructor.PROCESS_ASSETS_STAGE_OPTIMIZE;
+
+    if (stage) {
+      compiler.hooks.compilation.tap(pluginName, (compilation) => {
+        const stageSettings = { name: pluginName, stage };
+        compilation.hooks.processAssets.tapPromise(stageSettings, () => this.run(compilation));
+      });
+    } else {
+      compiler.hooks.emit.tapPromise(pluginName, (compilation) => this.run(compilation));
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -15,13 +15,20 @@
     "email": "klimashkin@gmail.com"
   },
   "main": "index.js",
+  "scripts": {
+    "lint": "eslint index.js",
+    "fix": "eslint index.js --fix"
+  },
   "peerDependencies": {
     "postcss": "^8.0.9",
     "webpack": "^4.40.0"
   },
   "devDependencies": {
     "postcss": "^8.0.9",
-    "webpack": "^4.40.0"
+    "webpack": "^4.40.0",
+    "eslint": "^7.15.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.22.1"
   },
   "dependencies": {
     "fancy-log": "^1.3.3",
@@ -38,5 +45,19 @@
   ],
   "engines": {
     "node": ">=10.0.0"
+  },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "node": true,
+      "es2021": true
+    },
+    "extends": [
+      "airbnb-base"
+    ],
+    "parserOptions": {
+      "ecmaVersion": 12
+    },
+    "rules": {}
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,17 +15,15 @@
     "email": "klimashkin@gmail.com"
   },
   "main": "index.js",
+  "files": [],
   "scripts": {
     "lint": "eslint index.js",
     "fix": "eslint index.js --fix"
   },
   "peerDependencies": {
-    "postcss": "^8.0.9",
-    "webpack": "^4.40.0"
+    "webpack": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
-    "postcss": "^8.0.9",
-    "webpack": "^4.40.0",
     "eslint": "^7.15.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1"
@@ -33,7 +31,8 @@
   "dependencies": {
     "fancy-log": "^1.3.3",
     "human-size": "^1.1.0",
-    "webpack-sources": "^1.4.0"
+    "postcss": "^8.2.0",
+    "webpack-sources": "^2.2.0"
   },
   "keywords": [
     "css",


### PR DESCRIPTION
Hello.

In version 5 of the webpack, using your plugin began to lead to a warning:
> (node:11944) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
> BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
>         Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
>         Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
> (Use `node --trace-deprecation ...` to show where the warning was created)

I slightly corrected your code so as not to change the main functionality, so that it remains working in version 4 of the webpack, but it also stopped issuing warnings in version 5 of the webpack.

I also added linting and updated dependencies.

Hope this can be helpful to you.

Thank you for the plugin!