### PR TITLE
Check for assets to prevent running against empty compilation assets.

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,8 +93,10 @@ module.exports = class PostCSSAssetsPlugin {
 
     if (stage) {
       compiler.hooks.compilation.tap(pluginName, (compilation) => {
-        const stageSettings = { name: pluginName, stage };
-        compilation.hooks.processAssets.tapPromise(stageSettings, () => this.run(compilation));
+        if (Object.keys(compilation.assets).length) {
+          const stageSettings = { name: pluginName, stage };
+          compilation.hooks.processAssets.tapPromise(stageSettings, () => this.run(compilation));
+        }
       });
     } else {
       compiler.hooks.emit.tapPromise(pluginName, (compilation) => this.run(compilation));


### PR DESCRIPTION
Adds check for empty assets before running plugin against assets.