### PR TITLE
Move assets check later to actual hook process.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = class PostCSSAssetsPlugin {
   }
 
   run(assets) {
-    if (!(Object.keys(assets).length > 0)) {
+    if (Object.keys(assets).length === 0) {
       return Promise.resolve();
     }
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,10 @@ module.exports = class PostCSSAssetsPlugin {
     this.log = log ? fancyLog : () => {};
   }
 
-  run(compilation) {
-    const { assets } = compilation;
+  run(assets) {
+    if (!(Object.keys(assets).length > 0)) {
+      return Promise.resolve();
+    }
 
     this.log('PostCSSAssetsPlugin: Starting...');
 
@@ -94,10 +96,12 @@ module.exports = class PostCSSAssetsPlugin {
     if (stage) {
       compiler.hooks.compilation.tap(pluginName, (compilation) => {
         const stageSettings = { name: pluginName, stage };
-        compilation.hooks.processAssets.tapPromise(stageSettings, () => this.run(compilation));
+        compilation.hooks.processAssets.tapPromise(stageSettings, (assets) => {
+          return this.run(assets || compilation.assets);
+        });
       });
     } else {
-      compiler.hooks.emit.tapPromise(pluginName, (compilation) => this.run(compilation));
+      compiler.hooks.emit.tapPromise(pluginName, ({assets}) => this.run(assets));
     }
   }
 };


### PR DESCRIPTION
This PR fixes an earlier [fix](https://github.com/klimashkin/postcss-assets-webpack-plugin/pull/5) that meant to check for asset keys before running the plugin against those assets. The issue with the earlier fix was that it was checking in the wrong location (before the asset was emitted) causing false negatives and therefore not running the plugin when it should have. This fix moves the check into the proper location at the hook level where the context is most up to date.

![Screen Shot 2021-06-28 at 7 30 35 PM](https://user-images.githubusercontent.com/84821036/123728353-f505ae80-d847-11eb-9ccd-0a5eb97081d0.png)
