### PR TITLE
Update webpack-sources range

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fancy-log": "^1.3.3",
     "human-size": "^1.1.0",
     "postcss": "^8.2.0",
-    "webpack-sources": "^2.2.0"
+    "webpack-sources": "^2.2.0 || ^3.0.0"
   },
   "keywords": [
     "css",


### PR DESCRIPTION
`webpack@5` use `webpack-sources@3` now - https://github.com/webpack/webpack/commit/c3a0145b49e62fbda7fe1372b87b0cef517a6c7f

This fix try to avoid package duplicates